### PR TITLE
Move `rubocop` dependency to development.

### DIFF
--- a/rspec-timecop.gemspec
+++ b/rspec-timecop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency     'rspec-core', '>= 2.99.0'
   spec.add_runtime_dependency     'timecop',    '~> 0.8.0'
-  spec.add_runtime_dependency     'rubocop',    '>= 0.30.0'
+  spec.add_development_dependency 'rubocop',    '>= 0.30.0'
   spec.add_development_dependency 'bundler',    '~> 1.7'
   spec.add_development_dependency 'rake',       '~> 10.0'
   spec.add_development_dependency 'rspec',      '~> 2.99.0'


### PR DESCRIPTION
Hi there,

I believe that `rubocop` gem is not needed as the runtime dependency. It does not need to be installed with the project's `bundle install`.
