### PR TITLE
Fix CI, README, and dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rake spec
   coverage:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Test Coverage](https://codeclimate.com/github/sugarcrm/rspec-timecop/badges/coverage.svg)](https://codeclimate.com/github/sugarcrm/rspec-timecop/coverage)
 [![License](http://img.shields.io/badge/license-MIT-green.svg?style=flat)](LICENSE.txt)
 
-[![RubyDoc](http://img.shields.io/badge/docs-rdoc.info-blue.svg)](http://rubydoc.org/gems/rspec-timecop)
+[![RubyDoc](http://img.shields.io/badge/docs-rdoc.info-blue.svg)](http://rubydoc.info/gems/rspec-timecop)
 
 RSpec extension for controlling time within examples, using the [timecop gem](https://github.com/travisjeffery/timecop).
 
@@ -75,7 +75,7 @@ Links to other places on the web where this projects exists:
 * [Code Climate](https://codeclimate.com/github/sugarcrm/rspec-timecop)
 * [Github](https://github.com/sugarcrm/rspec-timecop)
 * [OpenHub](https://www.openhub.net/p/rspec-timecop)
-* [RubyDoc](https://rubydoc.org/gems/rspec-timecop)
+* [RubyDoc](https://rubydoc.info/gems/rspec-timecop)
 * [RubyGems](https://rubygems.org/gems/rspec-timecop)
 * [Ruby LibHunt](https://ruby.libhunt.com/rspec-timecop-alternatives)
 * [Ruby Toolbox](https://www.ruby-toolbox.com/projects/rspec-timecop)

--- a/rspec-timecop.gemspec
+++ b/rspec-timecop.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   # without limiting.
   spec.add_development_dependency 'bundler-audit'
   spec.add_development_dependency 'license_finder'
+  spec.add_development_dependency 'logger'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rake'


### PR DESCRIPTION
* fix Github Action failing to run on the different Ruby versions
* fix the RubyDoc URLs in the README
* add `logger` development dependency for `license_finder`, which will be required after Ruby v3.5